### PR TITLE
Make enter new game easier

### DIFF
--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -103,20 +103,29 @@ export default function GameTable({
         return newPlayers;
       });
     }
+    if (isNaN(parsed)) {
+      setPlayers((prevPlayers) => {
+        const newPlayers = [...prevPlayers];
+        newPlayers[index] = {
+          ...newPlayers[index],
+          gains: 0,
+        };
+        debouncedUpdate(newPlayers);
+        return newPlayers;
+      });
+    }
   };
 
   useEffect(() => {
-    setGainsInputs(
-      players.map((p) => {
-        if (p.gains) {
-          return chipMode
-            ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
-            : p.gains.toString();
-        }
-        return "";
-      })
-    );
-  }, [players, chipMode]);
+    setGainsInputs((prev) => {
+      return players.map((p, i) => {
+        if (prev[i] !== undefined) return prev[i];
+        return chipMode
+          ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
+          : p.gains.toString();
+      });
+    });
+  }, [players.length, chipMode]);
 
   return (
     <Table>

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -31,7 +31,12 @@ export default function GameTable({
   dollarPerBuyIn,
 }: GameTableProps) {
   const [gainsInputs, setGainsInputs] = useState<string[]>(
-    players.map((p) => p.gains.toString())
+    players.map((p) => {
+      if (p.gains) {
+        return p.gains?.toString();
+      }
+      return "";
+    })
   );
 
   const debouncedUpdate = useCallback(
@@ -101,11 +106,14 @@ export default function GameTable({
 
   useEffect(() => {
     setGainsInputs(
-      players.map((p) =>
-        chipMode
-          ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
-          : p.gains.toString()
-      )
+      players.map((p) => {
+        if (p.gains) {
+          return chipMode
+            ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
+            : p.gains.toString();
+        }
+        return "";
+      })
     );
   }, [players, chipMode]);
 

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -87,32 +87,28 @@ export default function GameTable({
       return newInputs;
     });
 
+    const updatePlayerGains = (gainValue: number) => {
+      setPlayers((prevPlayers) => {
+        const newPlayers = [...prevPlayers];
+        newPlayers[index] = {
+          ...newPlayers[index],
+          gains: gainValue,
+        };
+        debouncedUpdate(newPlayers);
+        return newPlayers;
+      });
+    };
+
     const parsed = parseFloat(value);
     if (!isNaN(parsed)) {
       const dollarValue = chipMode
         ? (parsed / chipsPerBuyIn) * dollarPerBuyIn
         : parsed;
 
-      setPlayers((prevPlayers) => {
-        const newPlayers = [...prevPlayers];
-        newPlayers[index] = {
-          ...newPlayers[index],
-          gains: dollarValue,
-        };
-        debouncedUpdate(newPlayers);
-        return newPlayers;
-      });
+      updatePlayerGains(dollarValue);
     }
     if (isNaN(parsed) && value !== "-" && value !== "-." && value !== ".") {
-      setPlayers((prevPlayers) => {
-        const newPlayers = [...prevPlayers];
-        newPlayers[index] = {
-          ...newPlayers[index],
-          gains: 0,
-        };
-        debouncedUpdate(newPlayers);
-        return newPlayers;
-      });
+      updatePlayerGains(0);
     }
   };
 
@@ -127,6 +123,13 @@ export default function GameTable({
     });
   }, [players, chipMode, chipsPerBuyIn, dollarPerBuyIn]);
 
+  const displayBuyIns = (player: Player) => {
+    if (!player.buyIns) return 0;
+    return chipMode
+      ? convertToChips(player.buyIns).toString()
+      : player.buyIns.toString();
+  };
+
   return (
     <Table>
       <TableHeader>
@@ -139,12 +142,6 @@ export default function GameTable({
       </TableHeader>
       <TableBody>
         {players.map((player, index) => {
-          const displayBuyIns = () => {
-            if (!player.buyIns) return 0;
-            return chipMode
-              ? convertToChips(player.buyIns).toString()
-              : player.buyIns.toString();
-          };
           return (
             <TableRow key={player.id}>
               <TableCell className=" p-2">
@@ -153,7 +150,7 @@ export default function GameTable({
               <TableCell className=" p-2">
                 <Input
                   type="number"
-                  value={displayBuyIns()}
+                  value={displayBuyIns(player)}
                   onChange={(e) =>
                     handleChange(index, "buyIns", e.target.value)
                   }
@@ -163,7 +160,7 @@ export default function GameTable({
               <TableCell className=" p-2">
                 <Input
                   type="text"
-                  value={gainsInputs[index] === "0" ? "" : gainsInputs[index]}
+                  value={gainsInputs[index]}
                   onChange={(e) => handleChangeGains(index, e.target.value)}
                 />
               </TableCell>

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -17,28 +17,52 @@ type GameTableProps = {
   players: Player[];
   handleDelete: (index: number) => void;
   setPlayers: React.Dispatch<React.SetStateAction<Player[]>>;
+  chipMode: boolean;
+  chipsPerBuyIn: number;
+  dollarPerBuyIn: number;
 };
 
 export default function GameTable({
   players,
   handleDelete,
   setPlayers,
+  chipMode,
+  chipsPerBuyIn,
+  dollarPerBuyIn,
 }: GameTableProps) {
+  const [gainsInputs, setGainsInputs] = useState<string[]>(
+    players.map((p) => p.gains.toString())
+  );
+
   const debouncedUpdate = useCallback(
     debounce((newPlayers) => {
       localStorage.setItem("players", JSON.stringify(newPlayers));
       setPlayers(newPlayers);
     }, 500),
-    []
+    [setPlayers]
   );
 
-  const handleChange = (index: number, field: keyof Player, value: string) => {
-    setPlayers((prevPlayers) => {
-      const newPlayers = prevPlayers.map((player, i) =>
+  const convertToDollars = (chips: number) =>
+    (chips / chipsPerBuyIn) * dollarPerBuyIn;
+
+  const convertToChips = (dollars: number) =>
+    (dollars / dollarPerBuyIn) * chipsPerBuyIn;
+
+  const handleChange = (
+    index: number,
+    field: "buyIns" | "gains",
+    rawValue: string
+  ) => {
+    const parsed = parseFloat(rawValue);
+    const numericValue = isNaN(parsed) ? 0 : parsed;
+    const converted = chipMode ? convertToDollars(numericValue) : numericValue;
+
+    setPlayers((prev) => {
+      const newPlayers = prev.map((player, i) =>
         i === index
           ? {
               ...player,
-              [field]: (field === "buyIns" && parseFloat(value)) || 0,
+              [field]: converted,
             }
           : player
       );
@@ -49,70 +73,96 @@ export default function GameTable({
   };
 
   const handleChangeGains = (index: number, value: string) => {
-    if (/^-?\d*\.?\d*$/.test(value) || value === "") {
-      setPlayers((prevPlayers) => {
-        const newPlayers = prevPlayers.map((player, i) =>
-          i === index
-            ? {
-                ...player,
-                gains: value,
-              }
-            : player
-        );
+    if (!/^[-]?\d*\.?\d*$/.test(value)) return;
 
+    setGainsInputs((prev) => {
+      const newInputs = [...prev];
+      newInputs[index] = value;
+      return newInputs;
+    });
+
+    const parsed = parseFloat(value);
+    if (!isNaN(parsed)) {
+      const dollarValue = chipMode
+        ? (parsed / chipsPerBuyIn) * dollarPerBuyIn
+        : parsed;
+
+      setPlayers((prevPlayers) => {
+        const newPlayers = [...prevPlayers];
+        newPlayers[index] = {
+          ...newPlayers[index],
+          gains: dollarValue,
+        };
         debouncedUpdate(newPlayers);
         return newPlayers;
       });
     }
   };
 
+  useEffect(() => {
+    setGainsInputs(
+      players.map((p) =>
+        chipMode
+          ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
+          : p.gains.toString()
+      )
+    );
+  }, [players, chipMode]);
+
   return (
     <Table>
       <TableHeader>
         <TableRow>
           <TableHead>Player</TableHead>
-          <TableHead>Buy Ins</TableHead>
-          <TableHead>Gains</TableHead>
+          <TableHead>Buy Ins {chipMode ? "(chips)" : "(dollars)"}</TableHead>
+          <TableHead>Gains {chipMode ? "(chips)" : "(dollars)"}</TableHead>
           <TableHead>Actions</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {players.map((player, index) => (
-          <TableRow key={index}>
-            <TableCell>
-              <Input
-                type="text"
-                value={player.name}
-                onChange={(e) => handleChange(index, "name", e.target.value)}
-                className="border p-1 w-full"
-              />
-            </TableCell>
-            <TableCell>
-              <Input
-                type="text"
-                inputMode="decimal"
-                value={player.buyIns.toString()}
-                onChange={(e) => handleChange(index, "buyIns", e.target.value)}
-                className="border p-1 w-full"
-              />
-            </TableCell>
-            <TableCell>
-              <Input
-                type="text"
-                value={player.gains === 0 ? "" : player.gains.toString()}
-                onChange={(e) =>
-                  handleChangeGains(index, e.target.value.toString())
-                }
-                className="border p-1 w-full"
-              />
-            </TableCell>
-            <TableCell>
-              <Button variant="destructive" onClick={() => handleDelete(index)}>
-                Delete
-              </Button>
-            </TableCell>
-          </TableRow>
-        ))}
+        {players.map((player, index) => {
+          const displayBuyIns = chipMode
+            ? convertToChips(player.buyIns).toString()
+            : player.buyIns.toString();
+
+          return (
+            <TableRow key={player.id}>
+              <TableCell>
+                <Input
+                  type="text"
+                  value={player.name}
+                  readOnly
+                  className="border p-1 w-full bg-muted text-muted-foreground"
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="number"
+                  value={displayBuyIns}
+                  onChange={(e) =>
+                    handleChange(index, "buyIns", e.target.value)
+                  }
+                  className="border p-1 w-full"
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="text"
+                  value={gainsInputs[index] === "0" ? "" : gainsInputs[index]}
+                  onChange={(e) => handleChangeGains(index, e.target.value)}
+                />
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="destructive"
+                  onClick={() => handleDelete(index)}
+                >
+                  Delete
+                </Button>
+              </TableCell>
+            </TableRow>
+          );
+        })}
       </TableBody>
     </Table>
   );

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Player } from "@prisma/client";
 import { debounce } from "lodash";
+import { Trash2 } from "lucide-react";
 
 type GameTableProps = {
   players: Player[];
@@ -135,15 +136,10 @@ export default function GameTable({
 
           return (
             <TableRow key={player.id}>
-              <TableCell>
-                <Input
-                  type="text"
-                  value={player.name}
-                  readOnly
-                  className="border p-1 w-full bg-muted text-muted-foreground"
-                />
+              <TableCell className=" p-2">
+                <p>{player.name}</p>
               </TableCell>
-              <TableCell>
+              <TableCell className=" p-2">
                 <Input
                   type="number"
                   value={displayBuyIns}
@@ -153,7 +149,7 @@ export default function GameTable({
                   className="border p-1 w-full"
                 />
               </TableCell>
-              <TableCell>
+              <TableCell className=" p-2">
                 <Input
                   type="text"
                   value={gainsInputs[index] === "0" ? "" : gainsInputs[index]}
@@ -162,7 +158,16 @@ export default function GameTable({
               </TableCell>
               <TableCell>
                 <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-red-500 hover:bg-red-100 md:hidden"
+                  onClick={() => handleDelete(index)}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+                <Button
                   variant="destructive"
+                  className="hidden md:inline-flex"
                   onClick={() => handleDelete(index)}
                 >
                   Delete

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -139,10 +139,12 @@ export default function GameTable({
       </TableHeader>
       <TableBody>
         {players.map((player, index) => {
-          const displayBuyIns = chipMode
-            ? convertToChips(player.buyIns).toString()
-            : player.buyIns.toString();
-
+          const displayBuyIns = () => {
+            if (!player.buyIns) return 0;
+            return chipMode
+              ? convertToChips(player.buyIns).toString()
+              : player.buyIns.toString();
+          };
           return (
             <TableRow key={player.id}>
               <TableCell className=" p-2">
@@ -151,7 +153,7 @@ export default function GameTable({
               <TableCell className=" p-2">
                 <Input
                   type="number"
-                  value={displayBuyIns}
+                  value={displayBuyIns()}
                   onChange={(e) =>
                     handleChange(index, "buyIns", e.target.value)
                   }

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -103,7 +103,7 @@ export default function GameTable({
         return newPlayers;
       });
     }
-    if (isNaN(parsed)) {
+    if (isNaN(parsed) && value !== "-" && value !== "-." && value !== ".") {
       setPlayers((prevPlayers) => {
         const newPlayers = [...prevPlayers];
         newPlayers[index] = {

--- a/apps/web/src/app/(navigation)/games/components/GameTable.tsx
+++ b/apps/web/src/app/(navigation)/games/components/GameTable.tsx
@@ -117,15 +117,15 @@ export default function GameTable({
   };
 
   useEffect(() => {
-    setGainsInputs((prev) => {
-      return players.map((p, i) => {
-        if (prev[i] !== undefined) return prev[i];
+    setGainsInputs(() => {
+      return players.map((p) => {
+        if (!p.gains) return "";
         return chipMode
           ? ((p.gains / dollarPerBuyIn) * chipsPerBuyIn).toString()
           : p.gains.toString();
       });
     });
-  }, [players.length, chipMode]);
+  }, [players, chipMode, chipsPerBuyIn, dollarPerBuyIn]);
 
   return (
     <Table>

--- a/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
@@ -1,48 +1,55 @@
-import { Input } from "@/components/ui/input";
+"use client";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 
 type GameSettingsProps = {
-  showDollarAmount: boolean;
-  toggleShowDollarAmount: () => void;
-  moneyPerBuyIn?: number;
-  chipsPerBuyIn?: number;
-  setMoneyPerBuyIn: (value: number) => void;
-  setChipsPerBuyIn: (value: number) => void;
+  chipMode: boolean;
+  setChipMode: (v: boolean) => void;
+  chipsPerBuyIn: number;
+  setChipsPerBuyIn: (v: number) => void;
+  dollarPerBuyIn: number;
+  setDollarPerBuyIn: (v: number) => void;
 };
 
 export default function GameSettings({
-  showDollarAmount,
-  toggleShowDollarAmount,
-  moneyPerBuyIn,
+  chipMode,
+  setChipMode,
   chipsPerBuyIn,
-  setMoneyPerBuyIn,
   setChipsPerBuyIn,
+  dollarPerBuyIn,
+  setDollarPerBuyIn,
 }: GameSettingsProps) {
   return (
-    <div className="grid gap-4 py-4 border rounded p-4">
-      <div className="flex justify-center">
-        <p className="text-right">Game Settings</p>
-      </div>
-      <div className="grid grid-cols-4 items-center gap-4">
-        <Label htmlFor="chipOrDollar" className="text-right mr-4">
-          {showDollarAmount ? "Dollar Amount" : "Chip Amount"}
-        </Label>
+    <div className="mb-6 space-y-4">
+      <div className="flex items-center space-x-2">
         <Switch
-          onCheckedChange={toggleShowDollarAmount}
-          checked={!showDollarAmount}
+          id="toggle-chip-mode"
+          checked={chipMode}
+          onCheckedChange={setChipMode}
         />
-      </div>
-      <div className="grid grid-cols-4 items-center gap-4">
-        <Label htmlFor="moneyPerBuyIn" className=" text-right">
-          {showDollarAmount ? "$ Per Buy In" : "Chips Per Buy In"}
+        <Label htmlFor="toggle-chip-mode">
+          {chipMode ? "Chip Mode" : "Dollar Mode"}
         </Label>
-        <Input
-          id="moneyPerBuyIn"
-          name="moneyPerBuyIn"
-          className="col-span-3 md:w-1/2"
-          type="number"
-        />
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div>
+          <Label>Chips Per Buy-In</Label>
+          <Input
+            type="number"
+            value={chipsPerBuyIn}
+            onChange={(e) => setChipsPerBuyIn(+e.target.value)}
+          />
+        </div>
+        <div>
+          <Label>Dollar Per Buy-In</Label>
+          <Input
+            type="number"
+            value={dollarPerBuyIn}
+            onChange={(e) => setDollarPerBuyIn(+e.target.value)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
@@ -21,34 +21,36 @@ export default function GameSettings({
   setDollarPerBuyIn,
 }: GameSettingsProps) {
   return (
-    <div className="mb-6 space-y-4">
-      <div className="flex items-center space-x-2">
-        <Switch
-          id="toggle-chip-mode"
-          checked={chipMode}
-          onCheckedChange={setChipMode}
-        />
-        <Label htmlFor="toggle-chip-mode">
-          {chipMode ? "Chip Mode" : "Dollar Mode"}
-        </Label>
-      </div>
-
-      <div className="flex items-center gap-4">
-        <div>
-          <Label>Chips Per Buy-In</Label>
-          <Input
-            type="number"
-            value={chipsPerBuyIn}
-            onChange={(e) => setChipsPerBuyIn(+e.target.value)}
+    <div className=" flex justify-center">
+      <div className="mb-6 space-y-4">
+        <div className="flex items-center space-x-2">
+          <Switch
+            id="toggle-chip-mode"
+            checked={chipMode}
+            onCheckedChange={setChipMode}
           />
+          <Label htmlFor="toggle-chip-mode">
+            {chipMode ? "Chip Mode" : "Dollar Mode"}
+          </Label>
         </div>
-        <div>
-          <Label>Dollar Per Buy-In</Label>
-          <Input
-            type="number"
-            value={dollarPerBuyIn}
-            onChange={(e) => setDollarPerBuyIn(+e.target.value)}
-          />
+
+        <div className="flex items-center gap-4">
+          <div>
+            <Label>Chips Per Buy-In</Label>
+            <Input
+              type="number"
+              value={chipsPerBuyIn}
+              onChange={(e) => setChipsPerBuyIn(+e.target.value)}
+            />
+          </div>
+          <div>
+            <Label>Dollar Per Buy-In</Label>
+            <Input
+              type="number"
+              value={dollarPerBuyIn}
+              onChange={(e) => setDollarPerBuyIn(+e.target.value)}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
@@ -39,6 +39,7 @@ export default function GameSettings({
             <Label>Chips Per Buy-In</Label>
             <Input
               type="number"
+              min={1}
               value={chipsPerBuyIn}
               onChange={(e) => setChipsPerBuyIn(+e.target.value)}
             />
@@ -47,6 +48,7 @@ export default function GameSettings({
             <Label>Dollar Per Buy-In</Label>
             <Input
               type="number"
+              min={1}
               value={dollarPerBuyIn}
               onChange={(e) => setDollarPerBuyIn(+e.target.value)}
             />

--- a/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+type GameSettingsProps = {
+  showDollarAmount: boolean;
+  toggleShowDollarAmount: () => void;
+};
+
+export default function GameSettings({
+  showDollarAmount,
+  toggleShowDollarAmount,
+}: GameSettingsProps) {
+  return (
+    <div className="grid gap-4 py-4">
+      <div className="grid grid-cols-4 items-center gap-4">
+        <Label htmlFor="chipOrDollar" className="text-right mr-4">
+          {showDollarAmount ? "Dollar Amount" : "Chip Amount"}
+        </Label>
+        <Switch
+          onCheckedChange={toggleShowDollarAmount}
+          checked={!showDollarAmount}
+        />
+      </div>
+      <div className="grid grid-cols-4 items-center gap-4">
+        <Label htmlFor="moneyPerBuyIn" className=" text-right">
+          {showDollarAmount ? "$ Per Buy In" : "Chips Per Buy In"}
+        </Label>
+        <Input
+          id="moneyPerBuyIn"
+          name="moneyPerBuyIn"
+          className="col-span-3 md:w-1/2"
+          type="number"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/GameSettings.tsx
@@ -5,14 +5,25 @@ import { Switch } from "@/components/ui/switch";
 type GameSettingsProps = {
   showDollarAmount: boolean;
   toggleShowDollarAmount: () => void;
+  moneyPerBuyIn?: number;
+  chipsPerBuyIn?: number;
+  setMoneyPerBuyIn: (value: number) => void;
+  setChipsPerBuyIn: (value: number) => void;
 };
 
 export default function GameSettings({
   showDollarAmount,
   toggleShowDollarAmount,
+  moneyPerBuyIn,
+  chipsPerBuyIn,
+  setMoneyPerBuyIn,
+  setChipsPerBuyIn,
 }: GameSettingsProps) {
   return (
-    <div className="grid gap-4 py-4">
+    <div className="grid gap-4 py-4 border rounded p-4">
+      <div className="flex justify-center">
+        <p className="text-right">Game Settings</p>
+      </div>
       <div className="grid grid-cols-4 items-center gap-4">
         <Label htmlFor="chipOrDollar" className="text-right mr-4">
           {showDollarAmount ? "Dollar Amount" : "Chip Amount"}

--- a/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
@@ -52,8 +52,6 @@ export default function SubmitPlayerForm({
             {
               id: state.data?.id,
               name: state.data?.name,
-              buyIns: parseFloat(state.data?.buyIns) || 0,
-              gains: parseFloat(state.data?.gains) || 0,
             },
           ])
         );
@@ -62,8 +60,6 @@ export default function SubmitPlayerForm({
           {
             id: state.data?.id,
             name: state.data?.name,
-            buyIns: parseFloat(state.data?.buyIns) || 0,
-            gains: parseFloat(state.data?.gains) || 0,
           },
         ];
       });

--- a/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 
 const initialState: ActionResponse = {
   success: false,
@@ -26,6 +27,7 @@ type SubmitPlayerFormProps = {
   isPending: boolean;
   state: ActionResponse;
   setAllPlayers: (players: Player[]) => void;
+  toggleExistingOrNewPlayer: () => void;
 };
 
 export default function SubmitPlayerForm({
@@ -36,6 +38,7 @@ export default function SubmitPlayerForm({
   isPending,
   state,
   setAllPlayers,
+  toggleExistingOrNewPlayer,
 }: SubmitPlayerFormProps) {
   const [existingPlayerId, setExistingPlayerId] = useState("");
 
@@ -71,6 +74,15 @@ export default function SubmitPlayerForm({
   return (
     <form action={action}>
       <div className="grid gap-4 py-4">
+        <div className="grid grid-cols-4 items-center gap-4">
+          <Label htmlFor="newOrExistingPlayer" className="text-right">
+            {isNewPlayer ? "New Player" : "Existing Player"}
+          </Label>
+          <Switch
+            onCheckedChange={toggleExistingOrNewPlayer}
+            checked={!isNewPlayer}
+          />
+        </div>
         <div className="grid grid-cols-4 items-center gap-4">
           <Label htmlFor="name" className="text-right">
             Name

--- a/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
@@ -69,7 +69,7 @@ export default function SubmitPlayerForm({
 
   return (
     <div className=" flex justify-center">
-      <form action={action} className="mb-6 space-y-4">
+      <form action={action} className="mb-6 space-y-4 w-full md:w-[360px]">
         <div className="flex items-center space-x-2">
           <Label htmlFor="newOrExistingPlayer" className="text-right">
             {isNewPlayer ? "New Player" : "Existing Player"}

--- a/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
@@ -72,9 +72,9 @@ export default function SubmitPlayerForm({
   }, [state]);
 
   return (
-    <form action={action}>
-      <div className="grid gap-4 py-4">
-        <div className="grid grid-cols-4 items-center gap-4">
+    <div className=" flex justify-center">
+      <form action={action} className="mb-6 space-y-4">
+        <div className="flex items-center space-x-2">
           <Label htmlFor="newOrExistingPlayer" className="text-right">
             {isNewPlayer ? "New Player" : "Existing Player"}
           </Label>
@@ -83,7 +83,7 @@ export default function SubmitPlayerForm({
             checked={!isNewPlayer}
           />
         </div>
-        <div className="grid grid-cols-4 items-center gap-4">
+        <div className="flex items-center space-x-2">
           <Label htmlFor="name" className="text-right">
             Name
           </Label>
@@ -111,61 +111,23 @@ export default function SubmitPlayerForm({
             </p>
           )}
         </div>
-        {/* <div className="grid grid-cols-4 items-center gap-4">
-          <Label htmlFor="buyIns" className="text-right">
-            Buy Ins
-          </Label>
-          <Input
-            id="buyIns"
-            type="number"
-            name="buyIns"
-            required
-            className="col-span-3 md:w-1/2"
-            placeholder="Enter Buy Ins"
-            defaultValue={state.inputs?.buyIns}
-          />
-          {state?.errors?.buyIns && (
-            <p id="streetAddress-error" className="text-sm text-red-500">
-              {state.errors.buyIns[0]}
-            </p>
+        <div className="flex justify-between">
+          <Button variant="default" type="submit" disabled={isPending}>
+            {isPending ? "Submitting..." : "Submit"}
+          </Button>
+
+          {state.message && (
+            <>
+              {state.success ? (
+                <p className="text-center text-primary">{state.message}</p>
+              ) : (
+                <p className="text-center text-red-500">{state.message}</p>
+              )}
+            </>
           )}
         </div>
-        <div className="grid grid-cols-4 items-center gap-4">
-          <Label htmlFor="gains" className="text-right">
-            <span>Gains</span>
-          </Label>
-          <Input
-            id="gains"
-            type="text"
-            name="gains"
-            className="col-span-3 md:w-1/2"
-            pattern="-?[0-9]*\.?[0-9]*"
-            placeholder="Enter Gains"
-            defaultValue={state.inputs?.gains}
-          />
-          {state?.errors?.gains && (
-            <p id="streetAddress-error" className="text-sm text-red-500">
-              {state.errors.gains[0]}
-            </p>
-          )}
-        </div> */}
-      </div>
-      <div className="flex justify-between">
-        <Button variant="default" type="submit" disabled={isPending}>
-          {isPending ? "Submitting..." : "Submit"}
-        </Button>
-
-        {state.message && (
-          <>
-            {state.success ? (
-              <p className="text-center text-primary">{state.message}</p>
-            ) : (
-              <p className="text-center text-red-500">{state.message}</p>
-            )}
-          </>
-        )}
-      </div>
-    </form>
+      </form>
+    </div>
   );
 }
 

--- a/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/component/SubmitPlayerForm.tsx
@@ -111,7 +111,7 @@ export default function SubmitPlayerForm({
             </p>
           )}
         </div>
-        <div className="grid grid-cols-4 items-center gap-4">
+        {/* <div className="grid grid-cols-4 items-center gap-4">
           <Label htmlFor="buyIns" className="text-right">
             Buy Ins
           </Label>
@@ -148,7 +148,7 @@ export default function SubmitPlayerForm({
               {state.errors.gains[0]}
             </p>
           )}
-        </div>
+        </div> */}
       </div>
       <div className="flex justify-between">
         <Button variant="default" type="submit" disabled={isPending}>

--- a/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
+++ b/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
@@ -1,6 +1,6 @@
 import { Player } from "@prisma/client";
 
-export const calculateMissingGains = (
+export const showMissingGainsMessage = (
   players: Player[],
   chipMode: boolean,
   dollarPerBuyIn: number,

--- a/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
+++ b/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
@@ -1,0 +1,45 @@
+import { Player } from "@prisma/client";
+
+export const calculateMissingGains = (
+  players: Player[],
+  chipMode: boolean,
+  dollarPerBuyIn: number,
+  chipsPerBuyIn: number
+) => {
+  const totalGains = players.reduce((acc, player) => {
+    if (player.gains === undefined) {
+      return acc;
+    }
+    return acc + player.gains;
+  }, 0);
+
+  if (totalGains > 0) {
+    if (chipMode) {
+      return (
+        "You have an excess of " +
+        Math.abs(totalGains * (chipsPerBuyIn / dollarPerBuyIn)) +
+        " in chips. Please check your inputs."
+      );
+    }
+    return (
+      "You have an excess of " +
+      totalGains +
+      " in gains. Please check your inputs."
+    );
+  }
+
+  if (totalGains < 0) {
+    if (chipMode) {
+      return (
+        "You are missing " +
+        Math.abs(totalGains * (chipsPerBuyIn / dollarPerBuyIn)) +
+        " in chips. Please check your inputs."
+      );
+    }
+    return (
+      "You are missing " +
+      Math.abs(totalGains) +
+      " in gains. Please check your inputs."
+    );
+  }
+};

--- a/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
+++ b/apps/web/src/app/(navigation)/games/new-game/lib/calculateMissingGains.ts
@@ -42,4 +42,5 @@ export const showMissingGainsMessage = (
       " in gains. Please check your inputs."
     );
   }
+  return null;
 };

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -10,6 +10,7 @@ import { Player } from "@prisma/client";
 import SubmitPlayerForm from "./component/SubmitPlayerForm";
 import { Input } from "@/components/ui/input";
 import GameSettings from "./component/GameSettings";
+import { calculateMissingGains } from "./lib/calculateMissingGains";
 
 export type UserFormData = {
   name: string;
@@ -105,6 +106,8 @@ export default function NewGamePage() {
     }
   }, []);
 
+  const totalBuyInsInChips = (totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn;
+
   return (
     <div>
       <div className=" flex justify-center">
@@ -147,9 +150,20 @@ export default function NewGamePage() {
       </div>
       <div className=" border-t mt-4 pt-4 text-green-500">
         <p className=" mb-2 ">Total Buy Ins in $$$: ${totalBuyIns}</p>
-        <p>
-          Total Buy Ins in Chips:{" "}
-          {(totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn} Chips
+        <p>Total Buy Ins in Chips: {totalBuyInsInChips} Chips</p>
+        <p className=" text-red-500">
+          {calculateMissingGains(
+            players,
+            chipMode,
+            dollarPerBuyIn,
+            chipsPerBuyIn
+          ) &&
+            calculateMissingGains(
+              players,
+              chipMode,
+              dollarPerBuyIn,
+              chipsPerBuyIn
+            )}
         </p>
       </div>
 

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -159,11 +159,9 @@ export default function NewGamePage() {
         <p className=" mb-2">
           Total Buy Ins in Chips: {totalBuyInsInChips} Chips
         </p>
-        <p className=" text-red-500">
-          {missingGainsMessage && (
-            <p className="text-red-500">{missingGainsMessage}</p>
-          )}
-        </p>
+        {missingGainsMessage && (
+          <p className="text-red-500">{missingGainsMessage}</p>
+        )}
       </div>
 
       <div className=" mt-4">

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -76,7 +76,12 @@ export default function NewGamePage() {
     }
   };
 
-  const totalBuyIns = players.reduce((acc, player) => acc + player.buyIns, 0);
+  const totalBuyIns = players.reduce((acc, player) => {
+    if (player.buyIns === undefined) {
+      return acc;
+    }
+    return acc + player.buyIns;
+  }, 0);
 
   useEffect(() => {
     async function fetchAllPlayers() {
@@ -140,8 +145,12 @@ export default function NewGamePage() {
           dollarPerBuyIn={dollarPerBuyIn}
         />
       </div>
-      <div className=" border-t mt-4 pt-4">
-        <p>Total Buy Ins: ${totalBuyIns}</p>
+      <div className=" border-t mt-4 pt-4 text-green-500">
+        <p className=" mb-2 ">Total Buy Ins in $$$: ${totalBuyIns}</p>
+        <p>
+          Total Buy Ins in Chips:{" "}
+          {(totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn} Chips
+        </p>
       </div>
 
       <div className=" mt-4">

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -2,13 +2,10 @@
 import GameTable from "../components/GameTable";
 import { Button } from "@/components/ui/button";
 import { useActionState, useEffect, useState } from "react";
-import { Label } from "@/components/ui/label";
 import { createGame } from "@/app/actions/GameActions";
 import { getPlayers, submitPlayer } from "@/app/actions/PlayerActions";
-import { Switch } from "@/components/ui/switch";
 import { Player } from "@prisma/client";
 import SubmitPlayerForm from "./component/SubmitPlayerForm";
-import { Input } from "@/components/ui/input";
 import GameSettings from "./component/GameSettings";
 import { showMissingGainsMessage } from "./lib/calculateMissingGains";
 

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -107,6 +107,7 @@ export default function NewGamePage() {
   }, []);
 
   const totalBuyInsInChips = (totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn;
+  console.log("players", players);
 
   return (
     <div>

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -107,7 +107,6 @@ export default function NewGamePage() {
   }, []);
 
   const totalBuyInsInChips = (totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn;
-  console.log("players", players);
 
   return (
     <div>

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -49,6 +49,8 @@ export default function NewGamePage() {
   const [loading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [showDollarAmount, setShowDollarAmount] = useState(false);
+  const [chipsPerBuyIn, setChipsPerBuyIn] = useState(0);
+  const [moneyPerBuyIn, setMoneyPerBuyIn] = useState(0);
 
   const toggleExistingOrNewPlayer = () => {
     setIsNewPlayer(!isNewPlayer);
@@ -108,11 +110,18 @@ export default function NewGamePage() {
 
   return (
     <div>
+      <div className=" flex justify-center">
+        <h2 className=" font-bold text-3xl">New Game</h2>
+      </div>
       <div className="mb-4 border-b pb-4">
         <div className=" my-8">
           <GameSettings
             toggleShowDollarAmount={toggleShowDollarAmount}
             showDollarAmount={showDollarAmount}
+            moneyPerBuyIn={moneyPerBuyIn}
+            chipsPerBuyIn={chipsPerBuyIn}
+            setMoneyPerBuyIn={setMoneyPerBuyIn}
+            setChipsPerBuyIn={setChipsPerBuyIn}
           />
         </div>
         <SubmitPlayerForm

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -10,7 +10,7 @@ import { Player } from "@prisma/client";
 import SubmitPlayerForm from "./component/SubmitPlayerForm";
 import { Input } from "@/components/ui/input";
 import GameSettings from "./component/GameSettings";
-import { calculateMissingGains } from "./lib/calculateMissingGains";
+import { showMissingGainsMessage } from "./lib/calculateMissingGains";
 
 export type UserFormData = {
   name: string;
@@ -149,16 +149,18 @@ export default function NewGamePage() {
         />
       </div>
       <div className=" border-t mt-4 pt-4 text-green-500">
-        <p className=" mb-2 ">Total Buy Ins in $$$: ${totalBuyIns}</p>
-        <p>Total Buy Ins in Chips: {totalBuyInsInChips} Chips</p>
+        <p className=" mb-2">Total Buy Ins in $$$: ${totalBuyIns}</p>
+        <p className=" mb-2">
+          Total Buy Ins in Chips: {totalBuyInsInChips} Chips
+        </p>
         <p className=" text-red-500">
-          {calculateMissingGains(
+          {showMissingGainsMessage(
             players,
             chipMode,
             dollarPerBuyIn,
             chipsPerBuyIn
           ) &&
-            calculateMissingGains(
+            showMissingGainsMessage(
               players,
               chipMode,
               dollarPerBuyIn,

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -121,16 +121,6 @@ export default function NewGamePage() {
       </div>
       <div className="mb-4 border-b pb-4">
         <div className=" my-8">
-          <GameSettings
-            chipMode={chipMode}
-            setChipMode={setChipMode}
-            chipsPerBuyIn={chipsPerBuyIn}
-            setChipsPerBuyIn={setChipsPerBuyIn}
-            dollarPerBuyIn={dollarPerBuyIn}
-            setDollarPerBuyIn={setDollarPerBuyIn}
-          />
-        </div>
-        <div className=" my-8">
           <SubmitPlayerForm
             setPlayers={setPlayers}
             isNewPlayer={isNewPlayer}
@@ -140,6 +130,16 @@ export default function NewGamePage() {
             state={state}
             setAllPlayers={setAllPlayers}
             toggleExistingOrNewPlayer={toggleExistingOrNewPlayer}
+          />
+        </div>
+        <div className=" my-8">
+          <GameSettings
+            chipMode={chipMode}
+            setChipMode={setChipMode}
+            chipsPerBuyIn={chipsPerBuyIn}
+            setChipsPerBuyIn={setChipsPerBuyIn}
+            dollarPerBuyIn={dollarPerBuyIn}
+            setDollarPerBuyIn={setDollarPerBuyIn}
           />
         </div>
       </div>

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -26,13 +26,9 @@ export type ActionResponse = {
   data?: {
     id: string;
     name: string;
-    buyIns?: string | undefined;
-    gains?: string | undefined;
   };
   inputs?: {
     name: string;
-    buyIns?: string | undefined;
-    gains?: string | undefined;
   };
 };
 
@@ -48,16 +44,12 @@ export default function NewGamePage() {
   const [isNewPlayer, setIsNewPlayer] = useState(true);
   const [loading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [showDollarAmount, setShowDollarAmount] = useState(false);
-  const [chipsPerBuyIn, setChipsPerBuyIn] = useState(0);
-  const [moneyPerBuyIn, setMoneyPerBuyIn] = useState(0);
+  const [chipMode, setChipMode] = useState(true);
+  const [chipsPerBuyIn, setChipsPerBuyIn] = useState(500);
+  const [dollarPerBuyIn, setDollarPerBuyIn] = useState(5);
 
   const toggleExistingOrNewPlayer = () => {
     setIsNewPlayer(!isNewPlayer);
-  };
-
-  const toggleShowDollarAmount = () => {
-    setShowDollarAmount(!showDollarAmount);
   };
 
   const handleDelete = (index: number) => {
@@ -116,12 +108,12 @@ export default function NewGamePage() {
       <div className="mb-4 border-b pb-4">
         <div className=" my-8">
           <GameSettings
-            toggleShowDollarAmount={toggleShowDollarAmount}
-            showDollarAmount={showDollarAmount}
-            moneyPerBuyIn={moneyPerBuyIn}
+            chipMode={chipMode}
+            setChipMode={setChipMode}
             chipsPerBuyIn={chipsPerBuyIn}
-            setMoneyPerBuyIn={setMoneyPerBuyIn}
             setChipsPerBuyIn={setChipsPerBuyIn}
+            dollarPerBuyIn={dollarPerBuyIn}
+            setDollarPerBuyIn={setDollarPerBuyIn}
           />
         </div>
         <SubmitPlayerForm

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -8,6 +8,8 @@ import { getPlayers, submitPlayer } from "@/app/actions/PlayerActions";
 import { Switch } from "@/components/ui/switch";
 import { Player } from "@prisma/client";
 import SubmitPlayerForm from "./component/SubmitPlayerForm";
+import { Input } from "@/components/ui/input";
+import GameSettings from "./component/GameSettings";
 
 export type UserFormData = {
   name: string;
@@ -46,9 +48,14 @@ export default function NewGamePage() {
   const [isNewPlayer, setIsNewPlayer] = useState(true);
   const [loading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const [showDollarAmount, setShowDollarAmount] = useState(false);
 
   const toggleExistingOrNewPlayer = () => {
     setIsNewPlayer(!isNewPlayer);
+  };
+
+  const toggleShowDollarAmount = () => {
+    setShowDollarAmount(!showDollarAmount);
   };
 
   const handleDelete = (index: number) => {
@@ -102,16 +109,11 @@ export default function NewGamePage() {
   return (
     <div>
       <div className="mb-4 border-b pb-4">
-        <div className="flex justify-center items-center">
-          <div className="flex items-center space-x-2">
-            <Switch
-              onCheckedChange={toggleExistingOrNewPlayer}
-              checked={!isNewPlayer}
-            />
-            <Label htmlFor="newOrExistingPlayer">
-              {isNewPlayer ? "New Player" : "Existing Player"}
-            </Label>
-          </div>
+        <div className=" my-8">
+          <GameSettings
+            toggleShowDollarAmount={toggleShowDollarAmount}
+            showDollarAmount={showDollarAmount}
+          />
         </div>
         <SubmitPlayerForm
           setPlayers={setPlayers}
@@ -121,6 +123,7 @@ export default function NewGamePage() {
           isPending={isPending}
           state={state}
           setAllPlayers={setAllPlayers}
+          toggleExistingOrNewPlayer={toggleExistingOrNewPlayer}
         />
       </div>
 
@@ -134,7 +137,8 @@ export default function NewGamePage() {
       <div className=" border-t mt-4 pt-4">
         <p>Total Buy Ins: ${totalBuyIns}</p>
       </div>
-      <div className="mt-4">
+
+      <div className=" mt-4">
         <Button
           variant="default"
           type="button"

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -135,6 +135,9 @@ export default function NewGamePage() {
           players={players}
           handleDelete={handleDelete}
           setPlayers={setPlayers}
+          chipMode={chipMode}
+          chipsPerBuyIn={chipsPerBuyIn}
+          dollarPerBuyIn={dollarPerBuyIn}
         />
       </div>
       <div className=" border-t mt-4 pt-4">

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import GameTable from "../components/GameTable";
 import { Button } from "@/components/ui/button";
-import { useActionState, useEffect, useState } from "react";
+import { useActionState, useEffect, useMemo, useState } from "react";
 import { createGame } from "@/app/actions/GameActions";
 import { getPlayers, submitPlayer } from "@/app/actions/PlayerActions";
 import { Player } from "@prisma/client";
@@ -103,6 +103,15 @@ export default function NewGamePage() {
     }
   }, []);
 
+  const missingGainsMessage = useMemo(() => {
+    return showMissingGainsMessage(
+      players,
+      chipMode,
+      dollarPerBuyIn,
+      chipsPerBuyIn
+    );
+  }, [players, chipMode, dollarPerBuyIn, chipsPerBuyIn]);
+
   const totalBuyInsInChips = (totalBuyIns / dollarPerBuyIn) * chipsPerBuyIn;
 
   return (
@@ -151,18 +160,9 @@ export default function NewGamePage() {
           Total Buy Ins in Chips: {totalBuyInsInChips} Chips
         </p>
         <p className=" text-red-500">
-          {showMissingGainsMessage(
-            players,
-            chipMode,
-            dollarPerBuyIn,
-            chipsPerBuyIn
-          ) &&
-            showMissingGainsMessage(
-              players,
-              chipMode,
-              dollarPerBuyIn,
-              chipsPerBuyIn
-            )}
+          {missingGainsMessage && (
+            <p className="text-red-500">{missingGainsMessage}</p>
+          )}
         </p>
       </div>
 

--- a/apps/web/src/app/(navigation)/games/new-game/page.tsx
+++ b/apps/web/src/app/(navigation)/games/new-game/page.tsx
@@ -116,16 +116,18 @@ export default function NewGamePage() {
             setDollarPerBuyIn={setDollarPerBuyIn}
           />
         </div>
-        <SubmitPlayerForm
-          setPlayers={setPlayers}
-          isNewPlayer={isNewPlayer}
-          allPlayers={allPlayers}
-          action={action}
-          isPending={isPending}
-          state={state}
-          setAllPlayers={setAllPlayers}
-          toggleExistingOrNewPlayer={toggleExistingOrNewPlayer}
-        />
+        <div className=" my-8">
+          <SubmitPlayerForm
+            setPlayers={setPlayers}
+            isNewPlayer={isNewPlayer}
+            allPlayers={allPlayers}
+            action={action}
+            isPending={isPending}
+            state={state}
+            setAllPlayers={setAllPlayers}
+            toggleExistingOrNewPlayer={toggleExistingOrNewPlayer}
+          />
+        </div>
       </div>
 
       <div>

--- a/apps/web/src/app/actions/PlayerActions.ts
+++ b/apps/web/src/app/actions/PlayerActions.ts
@@ -40,8 +40,6 @@ const playerSchema = z
   .object({
     name: z.string().min(1, "Name is required").nullable().optional(),
     existingPlayerId: z.string().uuid().nullable().optional(),
-    buyIns: z.string().regex(/^\d+(\.\d{1,2})?$/, "Invalid buy-in amount"),
-    gains: z.string().regex(/^-?\d+(\.\d{1,2})?$/, "Invalid gains amount"),
   })
   .refine((data) => data.name || data.existingPlayerId, {
     message: "Either name or existingPlayerId is required",
@@ -56,8 +54,6 @@ export async function submitPlayer(
     const rawData = {
       name: formData.get("name") as string,
       existingPlayerId: formData.get("existingPlayerId") as string,
-      buyIns: formData.get("buyIns") as string,
-      gains: formData.get("gains") as string,
     };
 
     const validatedData = playerSchema.safeParse(rawData);
@@ -86,8 +82,6 @@ export async function submitPlayer(
       return {
         data: {
           ...player,
-          buyIns: validatedData.data.buyIns,
-          gains: validatedData.data.gains,
         },
         success: true,
         message: "User saved successfully!",


### PR DESCRIPTION
-made a toggle that allows to change the values from dollar to chip amounts and vice versa
-updated styling and new messages for total buyins in chips and dollars, and missing gains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced game interface displays buy-ins and gains with automatic conversion between chips and dollars.
  - Introduced a settings panel to toggle between chip and dollar modes with adjustable conversion rates.
  - Updated the player submission form with a toggle for new or existing players and a streamlined input layout.
  - Added clear user messaging for gains discrepancies.
  
- **Refactor**
  - Simplified player data handling by removing redundant fields for buy-ins and gains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->